### PR TITLE
Fixes issue #15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.lmig.forge.stash.ssh</groupId>
 	<artifactId>stash-ssh-key-enforcer</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT</version>
 	<organization>
 		<name>Liberty Mutual Insurance</name>
 		<url>https://libertymutual.com/</url>
@@ -185,6 +185,7 @@
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
 				<configuration>
+					<server>localhost</server>
 					<products>
 						<product>
 							<id>stash</id>

--- a/src/main/java/com/lmig/forge/stash/ssh/events/GeneralEventListener.java
+++ b/src/main/java/com/lmig/forge/stash/ssh/events/GeneralEventListener.java
@@ -19,17 +19,12 @@ package com.lmig.forge.stash.ssh.events;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import com.lmig.forge.stash.ssh.config.PluginSettingsService;
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.log4j.Logger;
 
 import com.atlassian.event.api.EventListener;
 import com.atlassian.stash.event.StashEvent;
-import com.atlassian.stash.event.permission.ProjectPermissionGrantRequestedEvent;
-import com.atlassian.stash.event.permission.RepositoryPermissionGrantRequestedEvent;
 import com.atlassian.stash.i18n.I18nService;
 import com.atlassian.stash.ssh.api.SshKey;
-import com.atlassian.stash.user.UserType;
 import com.lmig.forge.stash.ssh.keys.EnterpriseSshKeyService;
 
 public class GeneralEventListener {
@@ -52,7 +47,6 @@ public class GeneralEventListener {
     @EventListener
     public void mylistener(StashEvent stashEvent) {       
         if (SSH_KEY_CREATED_EVENT_CLASS.equals(stashEvent.getClass().getCanonicalName())) {
-            logger.warn("Key Create:" + ReflectionToStringBuilder.toString(stashEvent));
             try {
                 Method method = stashEvent.getClass().getMethod("getKey");
                 SshKey key = (SshKey) method.invoke(stashEvent);                
@@ -69,17 +63,6 @@ public class GeneralEventListener {
                 e.printStackTrace();
             }
         }else if (SSH_KEY_DELETED_EVENT_CLASS.equals(stashEvent.getClass().getCanonicalName())) {
-            // IF YOU READ THIS,  I'm sorry.
-            // I know reflection is BS and brittle, but it was the only way to get
-            // at the public "SshKey" using a non-public event.
-            // Reflection works
-            // BUT this cannot be casted to the atlassian object 
-            // https://developer.atlassian.com/static/javadoc/stash/3.11.2/ssh/reference/com/atlassian/stash/ssh/SshKeyCreatedEvent.html
-            // https://maven.atlassian.com/#nexus-search;classname~com.atlassian.stash.ssh.SshKeyCreatedEvent
-            // 
-            // Dependency included as compile and it compiles, but fails at run time
-            // with some other class failing.. and omitted throws NoClassDefFOund since the ssh-plugin does not export the class in question
-            // the osgi container won't let us have it in classpath.
             try {
                 Method method = stashEvent.getClass().getMethod("getKey");
                 SshKey key = (SshKey) method.invoke(stashEvent);                

--- a/src/main/resources/stash-ssh-key-enforcer.properties
+++ b/src/main/resources/stash-ssh-key-enforcer.properties
@@ -11,7 +11,7 @@ stash.ssh.reset.email.subject=Action Required: Reset Enterprise SSH Keys
 stash.ssh.reset.email.body=Your Key has been destroyed by the firey wrath of SSH Key Enforcer. Please generate a new key by visiting {0} 
 
 
-
+stashkeyenforcer.projectpermission.cancel=This Stash instance uses SSH Stash Key Enforcer. Users may not add keys directly to repositories or projects.
 
 
 


### PR DESCRIPTION
The StashEvent listener will catch all requests for keys at user, repo and project level and only rely on the user/group to approve or reject.  This will allow bamboo to create system keys at the repo level.
