### PR TITLE
Fixes issue #19 by adding DC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .project
 .idea
 *.iml
+src/test/resources/mysql-connector-java-5.1.40-bin.jar

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .idea
 *.iml
 src/test/resources/mysql-connector-java-5.1.40-bin.jar
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.lmig.forge.stash.ssh</groupId>
 	<artifactId>stash-ssh-key-enforcer</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.2-SNAPSHOT</version>
 	<organization>
 		<name>Liberty Mutual Insurance</name>
 		<url>https://libertymutual.com/</url>
@@ -263,8 +263,8 @@
 						<testGroup>
 							<id>clusterTestGroup</id>
 							<productIds>
-								<productId>stash-node-2</productId>
 								<productId>stash-node-1</productId>
+								<productId>stash-node-2</productId>
 							</productIds>
 						</testGroup>
 					</testGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -185,16 +185,89 @@
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
 				<configuration>
+                    <allowGoogleTracking>false</allowGoogleTracking>
 					<server>localhost</server>
+					<!-- run DC cluster using 'atlas-run \-\-testGroup clusterTestGroup' -->
+                    <!-- you will also need to download mysql driver and place in /home/lib for *all* nodes in cluster. See stash.shared.home values for each node below -->
+					<!-- see https://developer.atlassian.com/stash/docs/latest/how-tos/cluster-safe-plugins.html -->
+                    <!-- the file runClustered.sh aggregates some manipulations needed to make it easier, but starting a clister is sloooow -->
 					<products>
+						<!-- node 1 for clustered -->
 						<product>
 							<id>stash</id>
-							<instanceId>stash</instanceId>
+							<instanceId>stash-node-1</instanceId>
 							<version>${stash.version}</version>
 							<dataVersion>${stash.data.version}</dataVersion>
+							<systemPropertyVariables>
+								<stash.shared.home>${project.basedir}/target/stash-node-1/home/shared</stash.shared.home>
+                                <!-- override the SSH port used for this node -->
+                                <stash.plugin.ssh.port>7997</stash.plugin.ssh.port>
+								<!-- override database settings so both nodes use a single database -->
+								<jdbc.driver>com.mysql.jdbc.Driver</jdbc.driver>
+								<jdbc.url>jdbc:mysql://10.187.116.253:3306/cf_355c208f_d6d1_4f9b_b8c9_538453c89ec7?characterEncoding=utf8&amp;useUnicode=true&amp;sessionVariables=storage_engine%3DInnoDB</jdbc.url>
+								<jdbc.user>TcVfaZp8iohxwHMg</jdbc.user>
+								<jdbc.password>1vpJLjjMaoLVvozA</jdbc.password>
+								<!-- allow cluster nodes to find each other over TCP/IP thus enabling clustering for this node -->
+								<hazelcast.network.tcpip>true</hazelcast.network.tcpip>
+								<!-- set to true if your load balancer supports stick sessions -->
+								<hazelcast.http.stickysessions>false</hazelcast.http.stickysessions>
+								<!-- forces Stash to fully finish starting up before yielding to the func test runner or atlas-run -->
+								<johnson.spring.lifecycle.synchronousStartup>true</johnson.spring.lifecycle.synchronousStartup>
+							</systemPropertyVariables>
+                            <libArtifacts>
+                                <!-- ensure MySQL drivers are available to Stash -->
+                                <libArtifact>
+                                    <groupId>mysql</groupId>
+                                    <artifactId>mysql-connector-java</artifactId>
+                                    <version>5.1.32</version>
+                                </libArtifact>
+                            </libArtifacts>
+						</product>
+						<!-- Node 2 -->
+						<product>
+							<id>stash</id>
+							<instanceId>stash-node-2</instanceId>
+							<version>${stash.version}</version>
+							<dataVersion>${stash.data.version}</dataVersion>
+							<!-- override the HTTP port used for this node -->
+							<httpPort>7992</httpPort>
+							<systemPropertyVariables>
+								<stash.shared.home>${project.basedir}/target/stash-node-1/home/shared</stash.shared.home>
+								<!-- override the SSH port used for this node -->
+								<stash.plugin.ssh.port>7998</stash.plugin.ssh.port>
+								<!-- override database settings so both nodes use a single database -->
+								<jdbc.driver>com.mysql.jdbc.Driver</jdbc.driver>
+								<jdbc.url>jdbc:mysql://10.187.116.253:3306/cf_355c208f_d6d1_4f9b_b8c9_538453c89ec7?characterEncoding=utf8&amp;useUnicode=true&amp;sessionVariables=storage_engine%3DInnoDB</jdbc.url>
+								<jdbc.user>TcVfaZp8iohxwHMg</jdbc.user>
+								<jdbc.password>1vpJLjjMaoLVvozA</jdbc.password>
+								<!-- allow cluster nodes to find each other over TCP/IP thus enabling clustering for this node -->
+								<hazelcast.network.tcpip>true</hazelcast.network.tcpip>
+								<!-- set to true if your load balancer supports stick sessions -->
+								<hazelcast.http.stickysessions>false</hazelcast.http.stickysessions>
+								<!-- forces Stash to fully finish starting up before yielding to the func test runner or atlas-run -->
+								<johnson.spring.lifecycle.synchronousStartup>true</johnson.spring.lifecycle.synchronousStartup>
+							</systemPropertyVariables>
+							<libArtifacts>
+								<!-- ensure MySQL drivers are available to Stash -->
+								<libArtifact>
+									<groupId>mysql</groupId>
+									<artifactId>mysql-connector-java</artifactId>
+									<version>5.1.32</version>
+								</libArtifact>
+							</libArtifacts>
 						</product>
 					</products>
 					<!-- <log4jProperties>src/main/resources/log4j.properties</log4jProperties> -->
+					<testGroups>
+						<!-- tell AMPS / Maven which products ie nodes to run for the named testGroup 'clusterTestGroup' -->
+						<testGroup>
+							<id>clusterTestGroup</id>
+							<productIds>
+								<productId>stash-node-2</productId>
+								<productId>stash-node-1</productId>
+							</productIds>
+						</testGroup>
+					</testGroups>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -232,7 +305,7 @@
 		<stash.version>3.11.2</stash.version>
 		<stash.ssh.version>3.10.0</stash.ssh.version>
 		<stash.data.version>3.11.2</stash.data.version>
-		<amps.version>5.0.13</amps.version>
+		<amps.version>6.1.0</amps.version>
 		<plugin.testrunner.version>1.2.3</plugin.testrunner.version>
 		<ao.version>0.28.0</ao.version>
 	</properties>

--- a/runCluster.sh
+++ b/runCluster.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#bye bye whatever is there now!
+echo "recreating home directories from scratch"
+rm -R target/*
+
+
+#creat cluster home dirs for mysql lib
+mkdir -p target/stash-node-2/home/lib
+mkdir -p target/stash-node-1/home/lib
+mkdir -p target/stash-node-2/home/shared
+mkdir -p target/stash-node-1/home/shared
+cp src/test/resources/mysql-connector* target/stash-node-2/home/lib
+cp src/test/resources/mysql-connector* target/stash-node-1/home/lib
+
+
+echo "providing stash-config to clustered home for db settings"
+# set stash-config.properties with defaults and force db pool below CF max limit of 40 connections
+cat >>target/stash-node-1/home/shared/stash-config.properties <<EOF
+logging.logger.com.atlassian.stash=INFO
+logging.logger.com.atlassian.stash.internal.project=WARN
+logging.logger.ROOT=WARN
+feature.getting.started.page=false
+plugin.branch-permissions.feature.splash=false
+db.pool.partition.count=2
+db.pool.partition.connection.maximum=9
+EOF
+
+cat target/stash-node-1/home/shared/stash-config.properties > target/stash-node-2/home/shared/stash-config.properties
+
+echo "starting test group"
+# run with cluster optipn
+atlas-run -s ~/.m2/woek.xml  --testGroup clusterTestGroup

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -7,6 +7,7 @@
     <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <param name="plugin-icon">images/pluginIcon.png</param>
     <param name="plugin-logo">images/pluginLogo.png</param>
+    <param name="atlassian-data-center-compatible">true</param>
   </plugin-info>
   <!-- add our i18n resource -->
   <resource type="i18n" name="i18n" location="stash-ssh-key-enforcer"/>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -14,30 +14,17 @@
   <!-- add our web resources -->
   <web-resource key="stash-ssh-key-enforcer-resources" name="stash-ssh-key-enforcer Web Resources">
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>com.atlassian.soy.soy-template-plugin:soy-deps</dependency>
     <!-- transform calls to AJS.getText() inside JS files -->
     <transformation extension="js">
       <transformer key="jsI18n"/>
-    </transformation>
-    <!-- resource type="soy" name="supportTeamTab" location="/override-add-keys.soy"/> -->
-    <!-- transform Soy templates into JS -->
-    <transformation extension="soy">
-      <transformer key="soyTransformer"/>
     </transformation>
     <resource type="download" name="key-enforcer.js" location="/js/stash-ssh-key-enforcer.js"/>
     <context>atl.general</context>
   </web-resource>
   <web-resource key="stash-ssh-key-generator-resources" name="stash-ssh-key-enforcer Web Resources">
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>com.atlassian.soy.soy-template-plugin:soy-deps</dependency>
-    <!-- transform calls to AJS.getText() inside JS files -->
     <transformation extension="js">
       <transformer key="jsI18n"/>
-    </transformation>
-    <!-- resource type="soy" name="supportTeamTab" location="/override-add-keys.soy"/> -->
-    <!-- transform Soy templates into JS -->
-    <transformation extension="soy">
-      <transformer key="soyTransformer"/>
     </transformation>
     <resource type="download" name="key-enforcer.js" location="/js/stash-ssh-key-generating.js"/>
   </web-resource>

--- a/src/main/resources/stash-ssh-key-enforcer.properties
+++ b/src/main/resources/stash-ssh-key-enforcer.properties
@@ -8,7 +8,7 @@ key.enforcer.servlet.link.label=SSH Keys
 
 
 stash.ssh.reset.email.subject=Action Required: Reset Enterprise SSH Keys for Bitbucket
-stash.ssh.reset.email.body=The SSH Keypair used to authenticate with Bitbucket has been purged according to policy defined by the system to not let keys exceed an age of {1}. Please generate a new key by visiting {0}.
+stash.ssh.reset.email.body=The SSH Keypair used to authenticate with Bitbucket has been purged according to policy defined by the system to not let keys exceed an age of {1} day(s). Please generate a new key by visiting {0}.
 stash.ssh.reset.email.policy=You can also read more about your company''s policy here, {0}.
 
 stashkeyenforcer.projectpermission.cancel=This Stash instance uses SSH Stash Key Enforcer. Users may not add keys directly to repositories or projects.


### PR DESCRIPTION
Fixes issue #19 
- Plugin installs across all nodes
- Scheduled jobs run once per cluster
- UI/APIs are enforced across all nodes
- Added ability to run cluster via SDK for testing
- Limits # of db connections for each node to stay below DB max_connections